### PR TITLE
Dynamically grabs mailbox data and renders sidebar accordingly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,18 +9,24 @@ import store, {
   getMessageSnippet,
   formatSender,
   formatTime,
+  getMailboxes,
 } from './store';
 
-function getThreadIds() {
-  const { INBOX } = store.mailboxes;
-  if (INBOX == null) return [];
-  return INBOX.threadIds;
+function getThreadIds(mailboxName) {
+  // Use bracket notation for variable property look up
+  const mailbox = store.mailboxes[mailboxName];
+  // null check
+  return mailbox && mailbox.threadIds;
 }
 
-function renderSidebar() {
+function renderSidebar(mailboxName = 'INBOX') {
+  const threadIds = getThreadIds(mailboxName) || [];
   const sidebarContents = `
-    <h2 class="email-header">Inbox</h2>
-    <ul class="email-list">${getThreadIds()
+    <div>${getMailboxes(store)
+    .map(mailbox => `<a href="#"
+    data-mailbox-name="${mailbox}" class="email-header">${mailbox}</a>`)
+    .join('')}</div>
+    <ul class="email-list">${threadIds
     .map((threadId) => {
       const { messages } = store.threads[threadId];
       const messageMetadata = messages[messages.length - 1];
@@ -43,6 +49,14 @@ function renderSidebar() {
 
   const container = document.querySelector('.email-list-container');
   if (container != null) container.innerHTML = sidebarContents;
+
+  document.querySelectorAll('.email-header').forEach(node =>
+    node.addEventListener('click', (e: Event) => {
+      const { currentTarget } = e;
+      if (!(currentTarget instanceof HTMLElement)) return;
+      const name = currentTarget.dataset.mailboxName; // use data attributes
+      renderSidebar(name);
+    }));
 }
 
 renderSidebar();

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -61,4 +61,9 @@ export function formatTime(messageTimestamp: string): string {
   });
 }
 
+export function getMailboxes(mailboxesData: Data): string[] {
+  const { mailboxes } = mailboxesData;
+  return Object.keys(mailboxes);
+}
+
 export default store;


### PR DESCRIPTION
<img width="1345" alt="screen shot 2018-02-15 at 11 15 35 am" src="https://user-images.githubusercontent.com/19351087/36267354-a6f07902-1241-11e8-941b-76abbf5c8174.png">

This pull request adds Javascript code (functions, event listeners) to dynamically grab mailbox data. When the user clicks on a different mailbox name, the threads in that mailbox will be displayed in the sidebar.